### PR TITLE
Podcast migration v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 .DS_Store
 node_modules/
+/db/
 /wp/wp-content/plugins/akismet/
 /wp/wp-content/plugins/hello.php
 /wp/wp-content/themes/twentynineteen/
 /wp/wp-content/themes/twentytwenty/
 /wp/wp-content/themes/twentytwentyone/
 /wp/wp-content/themes/mediasanctuary/dist/
-/wp/wp-content/themes/mediasanctuary/db/
 /wp/wp-content/uploads/

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ node_modules/
 /wp/wp-content/themes/twentytwenty/
 /wp/wp-content/themes/twentytwentyone/
 /wp/wp-content/themes/mediasanctuary/dist/
+/wp/wp-content/themes/mediasanctuary/db/
 /wp/wp-content/uploads/

--- a/wp/wp-content/themes/mediasanctuary/db/migrate.php
+++ b/wp/wp-content/themes/mediasanctuary/db/migrate.php
@@ -1,0 +1,53 @@
+<?php
+
+add_action('after_setup_theme', function() {
+	if ( class_exists( '\WP_CLI' ) ) {
+		\WP_CLI::add_command('migrate', 'db_migrate', [
+			'shortdesc' => 'Run a content migration'
+		]);
+	}
+});
+
+function db_migrate($args) {
+	echo "Migrating content\n";
+
+	$version = get_option('db_migrate_version');
+	if (empty($version)) {
+		$version = 0;
+	}
+
+	$version++;
+
+	while ($migrate_step = db_migrate_step($version)) {
+		global $wpdb;
+		$wpdb->query("START TRANSACTION");
+		try {
+			echo "\n";
+			echo "Migration $version\n";
+			echo "----------------\n";
+			$migrate_step();
+			echo "\n";
+			//update_option('db_migrate_version', $version, false);
+		} catch (\Exception $err) {
+			echo "ERROR: " . $err->getMessage() . "\n";
+			echo "Rolling back database transaction\n";
+			$wpdb->query("ROLLBACK");
+			break;
+		}
+		$wpdb->query("COMMIT");
+		$version++;
+	}
+	echo "Finished migration\n";
+}
+
+function db_migrate_step($version) {
+	$theme_dir = get_template_directory();
+	$version_padded = str_pad($version, 4, '0', STR_PAD_LEFT);
+	$migrate_path = "$theme_dir/db/migrate_$version_padded.php";
+	if (! file_exists($migrate_path)) {
+		//echo "Could not find $migrate_path\n";
+		return false;
+	}
+	require_once($migrate_path);
+	return "db_migrate_v$version";
+}

--- a/wp/wp-content/themes/mediasanctuary/db/migrate.php
+++ b/wp/wp-content/themes/mediasanctuary/db/migrate.php
@@ -27,7 +27,7 @@ function db_migrate($args) {
 			echo "----------------\n";
 			$migrate_step();
 			echo "\n";
-			//update_option('db_migrate_version', $version, false);
+			update_option('db_migrate_version', $version, false);
 		} catch (\Exception $err) {
 			echo "ERROR: " . $err->getMessage() . "\n";
 			echo "Rolling back database transaction\n";

--- a/wp/wp-content/themes/mediasanctuary/db/migrate_0001.php
+++ b/wp/wp-content/themes/mediasanctuary/db/migrate_0001.php
@@ -1,0 +1,56 @@
+<?php
+
+function db_migrate_v1() {
+	echo "Migration number 1:\n";
+	echo "- For each 'podcast' add a 'soundcloud_podcast_track_id' or 'soundcloud_podcast_url'\n";
+	echo "- For each 'podcast' remove 'WOOC 105.3 FM: ' prefix from title\n";
+	echo "\n";
+
+	$posts = get_posts([
+		'post_type' => 'podcast',
+		'posts_per_page' => -1
+	]);
+
+	foreach ($posts as $post) {
+		echo "Migrating $post->post_title ($post->ID)\n";
+
+		$regex = '/^WOOC 105.3 FM: /';
+		if (preg_match($regex, $post->post_title, $matches)) {
+			$title = preg_replace($regex, '', $post->post_title);
+			echo "    new title: $title\n";
+			wp_update_post([
+				'ID' => $post->ID,
+				'post_title' => $title
+			]);
+		}
+
+		$track_id = get_post_meta($post->ID, 'soundcloud_podcast_track_id', true);
+		if (! empty($track_id)) {
+			echo "    skipped (has track id)\n";
+			continue;
+		}
+		$url = get_post_meta($post->ID, 'soundcloud_podcast_url', true);
+		if (! empty($url)) {
+			echo "    skipped (has url)\n";
+			continue;
+		}
+
+		$regex = '#https://soundcloud.com/mediasanctuary/[a-z0-9-]+#';
+		if (preg_match($regex, $post->post_content, $matches)) {
+			$url = $matches[0];
+			update_post_meta($post->ID, 'soundcloud_podcast_url', $url);
+			echo "    added url: $url\n";
+			continue;
+		}
+
+		$regex = '#api.soundcloud.com/tracks/(\d+)#';
+		if (preg_match($regex, $post->post_content, $matches)) {
+			$track_id = $matches[1];
+			update_post_meta($post->ID, 'soundcloud_podcast_track_id', $track_id);
+			echo "    added track id: $track_id\n";
+			continue;
+		}
+
+		echo "    WARNING: could not migrate track id or url\n";
+	}
+}

--- a/wp/wp-content/themes/mediasanctuary/functions.php
+++ b/wp/wp-content/themes/mediasanctuary/functions.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'post-types.php';
+require_once 'db/migrate.php';
 
 add_filter('show_admin_bar', '__return_false');
 


### PR DESCRIPTION
- Generate a `soundcloud_podcast_track_id` or `soundcloud_podcast_url` for each `podcast` post type that exists
- Remove `WOOC 105.3 FM: ` prefix from podcast post titles