### PR TITLE
Migrate press coverage

### DIFF
--- a/wp/wp-content/plugins/soundcloud-podcast/lib/import.php
+++ b/wp/wp-content/plugins/soundcloud-podcast/lib/import.php
@@ -86,7 +86,7 @@ function soundcloud_podcast_import($num = null, $url = null) {
 				'post_content' => soundcloud_podcast_track_content($track),
 				'post_date' => soundcloud_podcast_track_date($track)
 			]);
-			wp_set_post_terms($id, 'post-format-audio', 'post_format');
+			set_post_format($id, 'audio');
 			wp_set_post_tags($id, soundcloud_podcast_track_tags($track));
 
 			fputcsv($stdout, [

--- a/wp/wp-content/plugins/soundcloud-podcast/lib/import.php
+++ b/wp/wp-content/plugins/soundcloud-podcast/lib/import.php
@@ -52,6 +52,11 @@ function soundcloud_podcast_import($num = null, $url = null) {
 	$json = wp_remote_retrieve_body($rsp);
 	$tracks = json_decode($json, 'as hash');
 
+	if (empty($tracks['collection'])) {
+		fwrite($stderr, "Error: invalid JSON\n");
+		return;
+	}
+
 	foreach ($tracks['collection'] as $track) {
 
 		if (preg_match('/^HMM \d+ - \d+ - \d+$/', $track['title'])) {

--- a/wp/wp-content/themes/mediasanctuary/css/pages/_single.scss
+++ b/wp/wp-content/themes/mediasanctuary/css/pages/_single.scss
@@ -183,6 +183,16 @@
 	}
 }
 
+.tags {
+	margin-bottom: 10px;
+	font-size: 16px;
+	margin-bottom:20px;
+
+	a {
+		color: $c-blue-beetle;
+	}
+}
+
 .meta {
   display: flex;
   justify-content: space-between;

--- a/wp/wp-content/themes/mediasanctuary/db/migrate_0003.php
+++ b/wp/wp-content/themes/mediasanctuary/db/migrate_0003.php
@@ -1,0 +1,34 @@
+<?php
+
+function db_migrate_v3() {
+	echo "Migration number 3:\n";
+	echo "- Convert each 'press-coverage' post into a generic 'post'\n";
+	echo "- Add each migrated post to the 'Press Coverage' category\n";
+	echo "\n";
+
+	$news = term_exists('Sanctuary News', 'category');
+	$news_id = $news['term_id'];
+
+	$press = term_exists('Press Coverage', 'category');
+	if (! empty($press)) {
+		$press_id = $press['term_id'];
+	} else {
+		$press = wp_insert_term('Press Coverage', 'category', [
+			'parent' => $news_id
+		]);
+		$press_id = $press['term_id'];
+	}
+
+	$posts = get_posts([
+		'post_type' => 'press-coverage',
+		'posts_per_page' => -1
+	]);
+	foreach ($posts as $post) {
+		echo "Migrating $post->post_title ($post->ID)\n";
+		wp_update_post([
+			'ID' => $post->ID,
+			'post_type' => 'post',
+			'post_category' => [$news_id, $press_id]
+		]);
+	}
+}

--- a/wp/wp-content/themes/mediasanctuary/post-types.php
+++ b/wp/wp-content/themes/mediasanctuary/post-types.php
@@ -1,6 +1,7 @@
 <?php
 
 function setup_post_types() {
+	press_coverage_post_type(); // for import purposes only
 	project_post_type();
 }
 
@@ -33,6 +34,28 @@ function project_post_type() {
 			'has_archive'   => true,
 			'show_in_rest'  => true,
 			'supports'      => ['title', 'editor', 'thumbnail', 'revisions'],
+			'taxonomies'    => [],
+		)
+	);
+}
+
+function press_coverage_post_type() {
+
+	// This is only here for the purposes of migrating content.
+
+	$labels = [
+		'name'               => 'Press Coverage',
+		'singular_name'      => 'Press Coverage'
+	];
+
+	register_post_type(
+		'press-coverage',
+		array(
+			'labels'        => $labels,
+			'public'        => false,
+			'hierarchical'  => true,
+			'show_ui'       => false,
+			'has_archive'   => true,
 			'taxonomies'    => [],
 		)
 	);

--- a/wp/wp-content/themes/mediasanctuary/single.php
+++ b/wp/wp-content/themes/mediasanctuary/single.php
@@ -22,7 +22,16 @@
       if (! empty($cat)) {
         $cat .= ", ";
       }
-      $cat .= '<span class="categoryTag"><a href="' . esc_url( get_category_link( $category->term_id ) ) . '" class="tag alt" >' . esc_html( $category->name ) . '</a></span>';
+      $cat .= '<a href="' . esc_url( get_category_link( $category->term_id ) ) . '" class="category" >' . esc_html( $category->name ) . '</a>';
+    }
+
+    $tags = '';
+    $terms = get_the_terms($post, 'post_tag');
+    foreach ($terms as $term) {
+      if (! empty($tags)) {
+        $tags .= ", ";
+      }
+      $tags .= '<a href="' . esc_url( get_term_link( $term ) ) . '" class="tag" >' . esc_html( $term->name ) . '</a>';
     }
 
     if ($thumb_url) {
@@ -44,11 +53,20 @@
       if (function_exists('soundcloud_podcast') && get_post_format($post->ID) == 'audio') {
         soundcloud_podcast();
       }
-      echo $thumb;
+      if (! empty($thumb)) {
+        echo $thumb;
+      }
       the_content();
       echo '<br class="clear">';
+      ?>
 
-      ?></div>
+      <?php if (! empty($tags)) { ?>
+        <div class="tags">
+          Tags: <?php echo $tags; ?>
+        </div>
+      <?php } ?>
+
+      </div>
       <div class="meta">
         <ul class="social top" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="800">
           <li><strong>Share</strong></li>


### PR DESCRIPTION
- add a temporary `press-coverage` post type for importing purposes
- migrate those `press-coverage` posts to be generic `post` types
- apply Press Coverage category to those migrated posts
- show tag links in `single.php`