### PR TITLE
Redirects

### DIFF
--- a/wp/wp-content/themes/mediasanctuary/acf/group_607c30fdbda37.json
+++ b/wp/wp-content/themes/mediasanctuary/acf/group_607c30fdbda37.json
@@ -1,0 +1,83 @@
+{
+    "key": "group_607c30fdbda37",
+    "title": "Redirects",
+    "fields": [
+        {
+            "key": "field_607c3102b3801",
+            "label": "",
+            "name": "redirects",
+            "type": "repeater",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "collapsed": "",
+            "min": 0,
+            "max": 0,
+            "layout": "table",
+            "button_label": "Add Redirect",
+            "sub_fields": [
+                {
+                    "key": "field_607c3114b3802",
+                    "label": "From path",
+                    "name": "from_path",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "\/frompage",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                },
+                {
+                    "key": "field_607c3171b3803",
+                    "label": "Redirect to",
+                    "name": "redirect_to",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "default_value": "",
+                    "placeholder": "https:\/\/www.mediasanctuary.org\/to-page or \/to-page",
+                    "prepend": "",
+                    "append": "",
+                    "maxlength": ""
+                }
+            ]
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "options_page",
+                "operator": "==",
+                "value": "redirects"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "modified": 1618751950
+}

--- a/wp/wp-content/themes/mediasanctuary/functions.php
+++ b/wp/wp-content/themes/mediasanctuary/functions.php
@@ -98,6 +98,80 @@ add_action('init', function() {
 	setup_post_types();
 });
 
+add_action('template_redirect', function() {
+
+	// Check a configured list of redirects and if the current path matches
+	// the 'from_path' field, redirect to the 'redirect_to' field.
+
+	$redirects = get_field('redirects', 'options');
+	$url = parse_url($_SERVER['REQUEST_URI']);
+	$path = normalize_path($url['path']);
+	$redirect_to = false;
+
+	foreach ($redirects as $redirect) {
+		if (strpos($redirect['from_path'], '*') !== false) {
+			$redirect_to = check_wildcard_redirect($redirect, $path);
+			break;
+		} else {
+			$from_path = normalize_path($redirect['from_path']);
+			if ($path == $from_path) {
+				$redirect_to = $redirect['redirect_to'];
+				break;
+			}
+		}
+	}
+
+	if (! empty($redirect_to)) {
+		$redirect_to = apply_filters('redirect_to', $redirect_to, $redirect, $path);
+		wp_redirect($redirect_to);
+		exit;
+	}
+});
+
+function normalize_path($path) {
+	// Strip trailing slashes
+	if (substr($path, -1, 1) == '/') {
+		$path = substr($path, 0, -1);
+	}
+	return $path;
+}
+
+function check_wildcard_redirect($redirect, $path) {
+	// Return a redirect URL with wildcard replacements, if a match is found.
+	// Return false if the path does not match.
+	$from_pattern = str_replace('*', '(.*)', $redirect['from_path']);
+	$from_regex = '@^' . $from_pattern . '@i';
+	$redirect_to = $redirect['redirect_to'];
+	if (preg_match($from_regex, $path, $matches)) {
+		foreach ($matches as $index => $value) {
+			if ($index == 0) {
+				continue;
+			}
+			$count = 1;
+			$redirect_to = str_replace('*', $value, $redirect_to, $count);
+		}
+		return $redirect_to;
+	}
+	return false;
+}
+
+add_filter('redirect_to', function($redirect_to, $redirect) {
+	if ($redirect['from_path'] == '/podcasts/*') {
+		// Input: /stories/[slug]
+		// Output: /stories/[year]/[slug]
+		$regex = '@/stories/([^/]+)@';
+		if (preg_match($regex, $redirect_to, $matches)) {
+			$posts = get_posts([
+				'name' => $matches[1]
+			]);
+			if (! empty($posts)) {
+				return get_permalink($posts[0]->ID);
+			}
+		}
+	}
+	return $redirect_to;
+}, 10, 2);
+
 function asset_url($file) {
 	echo get_asset_url($file);
 }

--- a/wp/wp-content/themes/mediasanctuary/functions.php
+++ b/wp/wp-content/themes/mediasanctuary/functions.php
@@ -47,6 +47,14 @@ add_action('acf/init', function() {
 			'menu_slug'  => 'options',
 			'capability' => 'edit_others_posts'
 		]);
+		acf_add_options_page([
+			'page_title' => 'Redirects',
+			'menu_title' => 'Redirects',
+			'menu_slug'  => 'redirects',
+			'position'   => '20',
+			'icon_url'   => 'dashicons-redo',
+			'capability' => 'activate_plugins'
+		]);
 	}
 });
 


### PR DESCRIPTION
- adds a redirects option page with an ACF repeater
- allows for wildcard redirects `/podcasts/*` -> `/stories/*`
- filters the `redirect_to` value to allow more complex scenarios like `/podcasts/[slug]` -> `/stories/[year]/[slug]`