### PR TITLE
Internet Archive upload

### DIFF
--- a/wp-content/plugins/soundcloud-podcast/lib/cli.php
+++ b/wp-content/plugins/soundcloud-podcast/lib/cli.php
@@ -27,6 +27,14 @@ add_action('after_setup_theme', function() {
 					$cat = $args[1];
 				}
 				soundcloud_podcast_categories($cat);
+			} else if ($args[0] == 'export') {
+				$post_id = null;
+				if (! empty($args[1])) {
+					$post_id = intval($args[1]);
+					soundcloud_podcast_export($post_id);
+				} else {
+					soundcloud_podcast_export();
+				}
 			} else {
 				echo "Unknown subcommand {$args[0]}\n";
 			}

--- a/wp-content/plugins/soundcloud-podcast/lib/export.php
+++ b/wp-content/plugins/soundcloud-podcast/lib/export.php
@@ -1,0 +1,145 @@
+<?php
+
+function soundcloud_podcast_export($post_id = null) {
+	if ($post_id) {
+		$post = get_post($post_id);
+	} else {
+		$post = soundcloud_podcast_export_next_post();
+	}
+	if ($post) {
+		$track_id = get_post_meta($post->ID, 'soundcloud_podcast_id', true);
+		$dir = soundcloud_podcast_export_dir($post);
+		$files = soundcloud_podcast_export_files($post, $track_id, $dir);
+		print_r($files);
+	}
+}
+
+function soundcloud_podcast_export_next_post() {
+	$posts = get_posts([
+		'post_status' => 'publish',
+		'meta_query' => [
+			'relation' => 'AND',
+			'soundcloud_clause' => [
+				'key' => 'soundcloud_podcast_id',
+				'compare' => 'EXISTS'
+			],
+			'internet_archive_clause' => [
+				'key' => 'internet_archive_id',
+				'compare' => 'NOT EXISTS'
+			]
+		],
+		'post_count' => 1
+	]);
+	if (! empty($posts)) {
+		return $posts[0];
+	}
+	return false;
+}
+
+function soundcloud_podcast_export_id($post) {
+	return "media-sanctuary-" . $post->post_name;
+}
+
+function soundcloud_podcast_export_dir($post) {
+	$dir = $time = time();
+	$dir = "/tmp/export-$post->ID-$time";
+	mkdir($dir);
+	return $dir;
+}
+
+function soundcloud_podcast_export_files($post, $track_id, $dir) {
+	$wav = soundcloud_podcast_export_wav($post, $track_id, $dir);
+	$mp3 = soundcloud_podcast_export_mp3($post, $track_id, $dir);
+	if (! $wav || ! $mp3) {
+		return false;
+	}
+	$files = [$wav, $mp3];
+	$image = soundcloud_podcast_export_image($post);
+	if ($image) {
+		$files[] = $image;
+	}
+	$thumb = soundcloud_podcast_export_thumb($post);
+	if ($thumb) {
+		$files[] = $thumb;
+	}
+	return $files;
+}
+
+function soundcloud_podcast_export_wav($post, $track_id, $dir) {
+	$url = "https://api.soundcloud.com/tracks/$track_id/download";
+	$data = soundcloud_podcast_export_request($url);
+	if (! $data) {
+		return false;
+	}
+	$filename = soundcloud_podcast_export_id($post) . '.wav';
+	$path = "$dir/$filename";
+	$fh = fopen($path, 'w');
+	fwrite($fh, $data);
+	fclose($fh);
+	return $path;
+}
+
+function soundcloud_podcast_export_mp3($post, $track_id, $dir) {
+	$url = "https://api.soundcloud.com/tracks/$track_id/stream";
+	$data = soundcloud_podcast_export_request($url);
+	if (! $data) {
+		return false;
+	}
+	$filename = soundcloud_podcast_export_id($post) . '.mp3';
+	$path = "$dir/$filename";
+	$fh = fopen($path, 'w');
+	fwrite($fh, $data);
+	fclose($fh);
+	return $path;
+}
+
+function soundcloud_podcast_export_image($post) {
+	$attachment_id = get_post_thumbnail_id($post->ID);
+	if (! $attachment_id) {
+		return false;
+	}
+	$attachment = wp_get_attachment_metadata($attachment_id);
+	$uploads = wp_upload_dir();
+	return "{$uploads['basedir']}/{$attachment['file']}";
+}
+
+function soundcloud_podcast_export_thumb($post) {
+	$attachment_id = get_post_thumbnail_id($post->ID);
+	if (! $attachment_id) {
+		return false;
+	}
+	$attachment = wp_get_attachment_metadata($attachment_id);
+	$image_path = soundcloud_podcast_export_image($post);
+	$dir = dirname($image_path);
+	return "$dir/{$attachment['sizes']['thumbnail']['file']}";
+}
+
+function soundcloud_podcast_export_request($url) {
+	$stderr = fopen('php://stderr', 'w');
+	$access_token = soundcloud_podcast_token();
+
+	fwrite($stderr, "requesting $url\n");
+	$rsp = wp_remote_get($url, [
+		'headers' => [
+			'Accept' => 'application/json; charset=utf-8',
+			'Authorization' => "OAuth $access_token"
+		],
+		'timeout' => 60
+	]);
+
+	if (is_wp_error($rsp)) {
+		fwrite($stderr, "Error: " . $rsp->get_error_message() . "\n");
+		return false;
+	}
+
+	$status = wp_remote_retrieve_response_code($rsp);
+	$body = wp_remote_retrieve_body($rsp);
+
+	if ($status != 200) {
+		fwrite($stderr, "Error: HTTP $status\n");
+		fwrite($stderr, "$body\n");
+		return false;
+	}
+
+	return $body;
+}

--- a/wp-content/plugins/soundcloud-podcast/soundcloud-podcast.php
+++ b/wp-content/plugins/soundcloud-podcast/soundcloud-podcast.php
@@ -15,6 +15,8 @@ require_once __DIR__ . '/lib/export.php';
 require_once __DIR__ . '/lib/inventory.php';
 require_once __DIR__ . '/lib/categories.php';
 
+add_image_size('internet_archive_thumbnail', 280, 0);
+
 function soundcloud_podcast() {
 	global $post;
 

--- a/wp-content/plugins/soundcloud-podcast/soundcloud-podcast.php
+++ b/wp-content/plugins/soundcloud-podcast/soundcloud-podcast.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/lib/auth.php';
 require_once __DIR__ . '/lib/rss.php';
 require_once __DIR__ . '/lib/cli.php';
 require_once __DIR__ . '/lib/import.php';
+require_once __DIR__ . '/lib/export.php';
 require_once __DIR__ . '/lib/inventory.php';
 require_once __DIR__ . '/lib/categories.php';
 

--- a/wp-content/themes/mediasanctuary/acf/group_621bab0368da5.json
+++ b/wp-content/themes/mediasanctuary/acf/group_621bab0368da5.json
@@ -1,0 +1,63 @@
+{
+    "key": "group_621bab0368da5",
+    "title": "Internet Archive",
+    "fields": [
+        {
+            "key": "field_621bab095cc04",
+            "label": "Access Key",
+            "name": "ia_access_key",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_621bab225cc05",
+            "label": "Secret Key",
+            "name": "ia_secret_key",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "options_page",
+                "operator": "==",
+                "value": "soundcloud"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": 0,
+    "modified": 1645980482
+}


### PR DESCRIPTION
- Add a WP-CLI command: `wp soundcloud-podcast export [post ID]` (if the post ID is omitted, it looks for the next post with a SoundCloud ID but no Internet Archive ID)
- Uploads include:
   - SoundCloud WAV file
   - Full size image from WordPress
   - Thumbnail image from WordPress
- Internet Archive URL follows the pattern: `https://archive.org/details/media-sanctuary-[post slug]`