### PR TITLE
internet archive embed migration

### DIFF
--- a/wp-content/plugins/soundcloud-podcast/soundcloud-podcast.php
+++ b/wp-content/plugins/soundcloud-podcast/soundcloud-podcast.php
@@ -24,27 +24,32 @@ function soundcloud_podcast() {
 		return;
 	}
 
-	$track_id = get_post_meta($post->ID, 'soundcloud_podcast_id', true);
-	if (empty($track_id)) {
-		return;
-	}
-
 	$sources = [];
-
 	$soundcloud_link = '';
+	$internet_archive_link = '';
+
+	$soundcloud_id = get_post_meta($post->ID, 'soundcloud_podcast_id', true);
+	if (! empty($soundcloud_id)) {
+		$sources[] = "/wp-json/soundcloud-podcast/v1/stream/$soundcloud_id";
+	}
 	$soundcloud_url = get_post_meta($post->ID, 'soundcloud_podcast_url', true);
 	if (! empty($soundcloud_url)) {
 		$soundcloud_link = "<a href=\"$soundcloud_url\" class=\"soundcloud-podcast__link\">Listen on SoundCloud</a>";
 	}
 
-	$internet_archive_link = '';
 	$internet_archive_id = get_post_meta($post->ID, 'internet_archive_id', true);
 	if (! empty($internet_archive_id) && $internet_archive_id != -1) {
 		$internet_archive_link = "<a href=\"https://archive.org/details/$internet_archive_id\" class=\"soundcloud-podcast__link\">Listen on Internet Archive</a>";
-		$sources[] = "https://archive.org/download/$internet_archive_id/$internet_archive_id.mp3";
+		if (strpos($internet_archive_id, '/') == false) {
+			$internet_archive_id = "$internet_archive_id/$internet_archive_id.mp3";
+		}
+		$internet_archive_id = preg_replace('/\.wav$/', '.mp3', $internet_archive_id);
+		$sources[] = "https://archive.org/download/$internet_archive_id";
 	}
 
-	$sources[] = "/wp-json/soundcloud-podcast/v1/stream/$track_id";
+	if (empty($sources)) {
+		return;
+	}
 
 	$source_elements = '';
 	foreach ($sources as $src) {

--- a/wp-content/themes/mediasanctuary/db/migrate_0004.php
+++ b/wp-content/themes/mediasanctuary/db/migrate_0004.php
@@ -1,0 +1,45 @@
+<?php
+
+function db_migrate_v4() {
+	echo "Migration number 4:\n";
+	echo "- Update HMM stories with old Internet Archive embeds\n";
+	echo "- Remove redundant images in the post_content\n";
+	echo "\n";
+
+	global $post;
+
+	$all = new WP_Query([
+		'posts_per_page' => -1
+	]);
+
+	$ia_regex = '#<iframe.+?src="https://archive.org/embed/([^&"]+).+?</iframe>#ms';
+	$img_regex = '#<img[^>]+>#ms';
+
+	while ($all->have_posts()) {
+		$all->the_post();
+		if (! is_story_post($post)) {
+			continue;
+		}
+		if (preg_match($ia_regex, $post->post_content, $matches)) {
+			$internet_archive_id = str_replace('+', ' ', $matches[1]);
+			echo "Updating $post->post_title ($post->ID) with Internet Archive ID $internet_archive_id\n";
+			echo "    " . get_permalink($post) . "\n";
+			$content = preg_replace($ia_regex, '', $post->post_content);
+			wp_update_post([
+				'ID' => $post->ID,
+				'post_content' => $content
+			]);
+			update_post_meta($post->ID, 'internet_archive_id', $internet_archive_id);
+		}
+		if (preg_match($img_regex, $post->post_content, $matches) &&
+		    has_post_thumbnail($post)) {
+			echo "Updating $post->post_title ($post->ID) with redundant content image\n";
+			echo "    " . get_permalink($post) . "\n";
+			$content = preg_replace($img_regex, '', $post->post_content);
+			wp_update_post([
+				'ID' => $post->ID,
+				'post_content' => $content
+			]);
+		}
+	}
+}


### PR DESCRIPTION
- Updates stories to replace `<iframe src="https://archive.org/embed/...` with a `internat_archive_id` post meta value
- Updates stories with existing thumbnails and images in the post content, stripping out the content images
- Updates the `soundcloud_podcast()` function to work when there's only Internet Archive content (no SoundCloud)
- Updates the `soundcloud_podcast()` function so that it can reference audio files in an Internet Archive "collection"